### PR TITLE
RC: 0.11.3 - Add a right margin to subtitles in `ExpandablePanel`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/core-components",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/src/components/containers/ExpandablePanel/index.tsx
+++ b/src/components/containers/ExpandablePanel/index.tsx
@@ -91,6 +91,7 @@ export default function ExpandablePanel({
           styleState === 'closed' ? 29 : styleState === 'focused' ? 34 : 39,
         color: componentStyle[styleState].header.textColor,
         transition: 'all .25s ease',
+        marginRight: 25,
       },
     ]);
 


### PR DESCRIPTION
* Long subtitles could previously go right to the end of the component and that didn't look very nice.